### PR TITLE
Fix datafordeler/dataforsyning for new Vidi version

### DIFF
--- a/agriteam.json
+++ b/agriteam.json
@@ -58,7 +58,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -76,7 +76,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -105,7 +105,7 @@
 		},
       {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "orto_foraar"
         ],
@@ -204,7 +204,7 @@
       },
       {
         "type": "wms",
-         "url": "/api/df/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
+         "url": "/api/datafordeler/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
         "layers": [
             "dtk_skaermkort_daempet"
         ],
@@ -248,7 +248,7 @@
       },
        {
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_25/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_25/1.0.0/WMS",
         "layers": [
             "dtk25"
         ],

--- a/brobyvaerkVand2.json
+++ b/brobyvaerkVand2.json
@@ -32,7 +32,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -50,7 +50,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -190,7 +190,7 @@
       },
        {
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_25/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_25/1.0.0/WMS",
         "layers": [
             "dtk25"
         ],
@@ -204,7 +204,7 @@
       },
       {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
           "geodanmark_2020_12_5cm"
         ],

--- a/edc_videbaek.json
+++ b/edc_videbaek.json
@@ -59,7 +59,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -77,7 +77,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -106,7 +106,7 @@
 		},
       {
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/forvaltning2",
         "layers": [
             "Basis_ortofoto"
         ],
@@ -205,7 +205,7 @@
       },
       {
         "type": "wms",
-         "url": "https://api.dataforsyningen.dk/service?servicename=topo_skaermkort&service=WMS&version=1.1.1&token=4aacd5977eb46ca012c260ecb608c65c",
+         "url": "/api/dataforsyningen/service?servicename=topo_skaermkort&service=WMS&version=1.1.1&token=4aacd5977eb46ca012c260ecb608c65c",
         "layers": [
             "dtk_skaermkort_daempet"
         ],

--- a/geosag_intern.json
+++ b/geosag_intern.json
@@ -64,7 +64,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -82,7 +82,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -111,7 +111,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_DAF?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_DAF",
 			"layers": [
 				"orto_foraar_12_5"
 			],
@@ -126,7 +126,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
 			"layers": [
 				"quickorto"
 			],

--- a/geosag_intern_test.json
+++ b/geosag_intern_test.json
@@ -52,7 +52,7 @@
 	"baseLayers": [
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -82,7 +82,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -111,7 +111,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_DAF?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_DAF",
 			"layers": [
 				"orto_foraar_12_5"
 			],
@@ -126,7 +126,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
 			"layers": [
 				"quickorto"
 			],

--- a/havnedemo.json
+++ b/havnedemo.json
@@ -14,7 +14,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -32,7 +32,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -61,7 +61,7 @@
 		},
 		{
 			"type": "wms",		
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_ortofoto"
 			],
@@ -76,7 +76,7 @@
 		},
         {
 			"type": "wms",		
-			"url": "https://api.dataforsyningen.dk/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
 			"layers": [
 				"quickorto"
 			],

--- a/ibspild.json
+++ b/ibspild.json
@@ -50,7 +50,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -68,7 +68,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -97,7 +97,7 @@
 		},
       {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "orto_foraar"
         ],
@@ -132,7 +132,7 @@
         },      
         {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "geodanmark_2018_12_5cm"
         ],
@@ -167,7 +167,7 @@
         },
       {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "geodanmark_2015_12_5cm"
         ],
@@ -202,7 +202,7 @@
         },
       {
         "type": "wms",
-         "url": "/api/df/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
+         "url": "/api/datafordeler/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
         "layers": [
             "dtk_skaermkort_daempet"
         ],
@@ -246,7 +246,7 @@
       },
        {
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_25/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_25/1.0.0/WMS",
         "layers": [
             "dtk25"
         ],

--- a/insar.json
+++ b/insar.json
@@ -40,7 +40,7 @@
       },
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -58,7 +58,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -87,7 +87,7 @@
 		},
       {
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/forvaltning2",
         "layers": [
             "Basis_ortofoto"
         ],

--- a/nibevarme2.json
+++ b/nibevarme2.json
@@ -30,7 +30,7 @@
 "baseLayers":[
         {
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -48,7 +48,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -77,7 +77,7 @@
 		},
       {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "orto_foraar"
         ],
@@ -112,7 +112,7 @@
         },
       {
         "type": "wms",
-         "url": "/api/df/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
+         "url": "/api/datafordeler/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
         "layers": [
             "dtk_skaermkort_daempet"
         ],

--- a/odder.json
+++ b/odder.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -57,7 +57,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -86,7 +86,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_DAF?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_DAF",
 			"layers": [
 				"orto_foraar_12_5"
 			],
@@ -101,7 +101,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
 			"layers": [
 				"quickorto"
 			],
@@ -131,7 +131,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_ortofoto"
 			],

--- a/roennehavn.json
+++ b/roennehavn.json
@@ -13,7 +13,7 @@
    "baseLayers":[
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -31,7 +31,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -60,7 +60,7 @@
 		},
 		{
 			"type": "wms",		
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_ortofoto"
 			],
@@ -75,7 +75,7 @@
 		},
         {
 			"type": "wms",		
-			"url": "https://api.dataforsyningen.dk/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/orto_foraar_temp?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
 			"layers": [
 				"quickorto"
 			],

--- a/seges.json
+++ b/seges.json
@@ -48,7 +48,7 @@
 "baseLayers":[
       {
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -66,7 +66,7 @@
 		},
 		{
 			"type": "wms",
-			"url": "/api/df/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
+			"url": "/api/datafordeler/Matrikel/MatrikelGaeldendeOgForeloebigWMS/1.0.0/WMS",
 			"layers": [
 				"Centroide_Gaeldende",
 				"OptagetVej_Gaeldende",
@@ -95,7 +95,7 @@
 		},
 	{
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "orto_foraar"
         ],
@@ -130,7 +130,7 @@
         },
 	{
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
         "layers": [
             "geodanmark_2019_12_5cm"
         ],
@@ -144,7 +144,7 @@
 	},
 	{
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
         "layers": [
             "geodanmark_2018_12_5cm"
         ],
@@ -158,7 +158,7 @@
 	},
 	{
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
         "layers": [
             "geodanmark_2017_12_5cm"
         ],
@@ -172,7 +172,7 @@
 	},
 	{
         "type": "wms",
-        "url": "https://api.dataforsyningen.dk/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
+        "url": "/api/dataforsyningen/orto_foraar_DAF?service=WMS&token=4aacd5977eb46ca012c260ecb608c65c",
         "layers": [
             "geodanmark_2016_12_5cm"
         ],
@@ -186,7 +186,7 @@
 	},
 	{
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_1000/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_1000/1.0.0/WMS",
         "layers": [
             "dtk_1000"
         ],
@@ -200,7 +200,7 @@
       },
        {
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_500/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_500/1.0.0/WMS",
         "layers": [
             "dtk500"
         ],
@@ -214,7 +214,7 @@
       },
        {
         "type": "wms",
-        "url": "/api/df/DKtopokort/dtk_25/1.0.0/WMS",
+        "url": "/api/datafordeler/DKtopokort/dtk_25/1.0.0/WMS",
         "layers": [
             "dtk25"
         ],

--- a/skagenhavn.json
+++ b/skagenhavn.json
@@ -24,7 +24,7 @@
     "baseLayers": [
 		{
 			"type": "wms",
-			"url": "https://api.dataforsyningen.dk/forvaltning2?token=4aacd5977eb46ca012c260ecb608c65c",
+			"url": "/api/dataforsyningen/forvaltning2",
 			"layers": [
 				"Basis_kort",
 				"Stednavne_basiskort",
@@ -53,7 +53,7 @@
         },
         {
             "type": "wms",
-            "url": "https://api.dataforsyningen.dk/orto_foraar_DAF?token=4aacd5977eb46ca012c260ecb608c65c",
+            "url": "/api/dataforsyningen/orto_foraar_DAF",
             "layers": [
                 "orto_foraar_12_5"
             ],

--- a/vmr.json
+++ b/vmr.json
@@ -12,7 +12,7 @@
     },
 {
         "type": "wms",
-        "url": "/api/df/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
+        "url": "/api/datafordeler/GeoDanmarkOrto/orto_foraar/1.0.0/WMS",
         "layers": [
             "orto_foraar"
         ],
@@ -47,7 +47,7 @@
         },
     {
         "type": "wms",
-         "url": "/api/df/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
+         "url": "/api/datafordeler/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
         "layers": [
             "dtk_skaermkort"
         ],
@@ -61,7 +61,7 @@
       },
     {
         "type": "wms",
-         "url": "/api/df/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
+         "url": "/api/datafordeler/Dkskaermkort/topo_skaermkort/1.0.0/WMS",
         "layers": [
             "dtk_skaermkort_daempet"
         ],


### PR DESCRIPTION
Due to changes in DF extension, URLs for dataforsyning/datafordeler is changed. token is set in config.